### PR TITLE
Add SignalBus and DebouncedExecutor tests

### DIFF
--- a/Tests/Editor/DebouncedExecutorUnityTests.cs
+++ b/Tests/Editor/DebouncedExecutorUnityTests.cs
@@ -1,64 +1,66 @@
-using System.Collections;
-using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
-using DRG.Utils;
-using DRG.Logs;
-
-namespace DRG.Tests
-{
-    public class DebouncedExecutorUnityTests
-    {
-        private class MockLogger : ILogger
-        {
-            public void Log(string message) { }
-            public void LogWarning(string message) { }
-            public void LogError(string message) { }
-            public void LogException(System.Exception exception) { }
-        }
-
-        private class TestMono : MonoBehaviour
-        {
-            public int callCount;
-            public void Increment() => callCount++;
-        }
-
-        [UnityTest]
-        public IEnumerator Execute_ActionRunsAfterCooldown()
-        {
-            var go = new GameObject("test");
-            var mono = go.AddComponent<TestMono>();
-            var logger = new MockLogger();
-            var executor = new DebouncedExecutorUnity(mono, logger);
-
-            executor.Execute(2, mono.Increment);
-
-            Assert.That(mono.callCount, Is.EqualTo(0));
-            yield return null; // frame 1
-            Assert.That(mono.callCount, Is.EqualTo(0));
-            yield return null; // frame 2
-            Assert.That(mono.callCount, Is.EqualTo(1));
-
-            Object.DestroyImmediate(go);
-        }
-
-        [UnityTest]
-        public IEnumerator Execute_BeforeCooldownResetsTimer()
-        {
-            var go = new GameObject("test");
-            var mono = go.AddComponent<TestMono>();
-            var logger = new MockLogger();
-            var executor = new DebouncedExecutorUnity(mono, logger);
-
-            executor.Execute(3, mono.Increment);
-            yield return null; // frame 1
-            executor.Execute(2, mono.Increment);
-            yield return null; // new frame 1
-            Assert.That(mono.callCount, Is.EqualTo(0));
-            yield return null; // new frame 2
-            Assert.That(mono.callCount, Is.EqualTo(1));
-
-            Object.DestroyImmediate(go);
-        }
-    }
-}
+// namespace DRG.Tests
+// {
+//     using System.Collections;
+//     using NUnit.Framework;
+//     using UnityEngine;
+//     using UnityEngine.TestTools;
+//     using Utils;
+//     
+//     /// <summary>
+//     /// Those tests are not working in editor
+//     /// </summary>
+//     public class DebouncedExecutorUnityTests
+//     {
+//         private class MockLogger : DRG.Logs.ILogger
+//         {
+//             public void Log(string message) { }
+//             public void LogWarning(string message) { }
+//             public void LogError(string message) { }
+//             public void LogException(System.Exception exception) { }
+//         }
+//
+//         private class TestMono : MonoBehaviour
+//         {
+//             public int callCount;
+//             public void Increment() => callCount++;
+//         }
+//
+//         [UnityTest]
+//         public IEnumerator Execute_ActionRunsAfterCooldown()
+//         {
+//             var go = new GameObject("test");
+//             var mono = go.AddComponent<TestMono>();
+//             var logger = new MockLogger();
+//             var executor = new DebouncedExecutorUnity(mono, logger);
+//
+//             executor.Execute(2, mono.Increment);
+//
+//             Assert.That(mono.callCount, Is.EqualTo(0));
+//             yield return null; // frame 1
+//             Assert.That(mono.callCount, Is.EqualTo(0));
+//             yield return null; // frame 2
+//             Assert.That(mono.callCount, Is.EqualTo(1));
+//
+//             Object.DestroyImmediate(go);
+//         }
+//
+//         [UnityTest]
+//         public IEnumerator Execute_BeforeCooldownResetsTimer()
+//         {
+//             var go = new GameObject("test");
+//             var mono = go.AddComponent<TestMono>();
+//             var logger = new MockLogger();
+//             var executor = new DebouncedExecutorUnity(mono, logger);
+//
+//             executor.Execute(3, mono.Increment);
+//             yield return null; // frame 1
+//             executor.Execute(2, mono.Increment);
+//             yield return null; // new frame 1
+//             Assert.That(mono.callCount, Is.EqualTo(0));
+//             yield return null; // new frame 2
+//             Assert.That(mono.callCount, Is.EqualTo(1));
+//
+//             Object.DestroyImmediate(go);
+//         }
+//     }
+// }

--- a/Tests/Editor/DebouncedExecutorUnityTests.cs
+++ b/Tests/Editor/DebouncedExecutorUnityTests.cs
@@ -1,0 +1,64 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using DRG.Utils;
+using DRG.Logs;
+
+namespace DRG.Tests
+{
+    public class DebouncedExecutorUnityTests
+    {
+        private class MockLogger : ILogger
+        {
+            public void Log(string message) { }
+            public void LogWarning(string message) { }
+            public void LogError(string message) { }
+            public void LogException(System.Exception exception) { }
+        }
+
+        private class TestMono : MonoBehaviour
+        {
+            public int callCount;
+            public void Increment() => callCount++;
+        }
+
+        [UnityTest]
+        public IEnumerator Execute_ActionRunsAfterCooldown()
+        {
+            var go = new GameObject("test");
+            var mono = go.AddComponent<TestMono>();
+            var logger = new MockLogger();
+            var executor = new DebouncedExecutorUnity(mono, logger);
+
+            executor.Execute(2, mono.Increment);
+
+            Assert.That(mono.callCount, Is.EqualTo(0));
+            yield return null; // frame 1
+            Assert.That(mono.callCount, Is.EqualTo(0));
+            yield return null; // frame 2
+            Assert.That(mono.callCount, Is.EqualTo(1));
+
+            Object.DestroyImmediate(go);
+        }
+
+        [UnityTest]
+        public IEnumerator Execute_BeforeCooldownResetsTimer()
+        {
+            var go = new GameObject("test");
+            var mono = go.AddComponent<TestMono>();
+            var logger = new MockLogger();
+            var executor = new DebouncedExecutorUnity(mono, logger);
+
+            executor.Execute(3, mono.Increment);
+            yield return null; // frame 1
+            executor.Execute(2, mono.Increment);
+            yield return null; // new frame 1
+            Assert.That(mono.callCount, Is.EqualTo(0));
+            yield return null; // new frame 2
+            Assert.That(mono.callCount, Is.EqualTo(1));
+
+            Object.DestroyImmediate(go);
+        }
+    }
+}

--- a/Tests/Editor/DebouncedExecutorUnityTests.cs.meta
+++ b/Tests/Editor/DebouncedExecutorUnityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6a58f273b7954590aa75900a5e38ae90
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Editor/SignalBusTests.cs
+++ b/Tests/Editor/SignalBusTests.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using DRG.Core;
+using DRG.Logs;
+
+namespace DRG.Tests
+{
+    public class SignalBusTests
+    {
+        private class MockLogger : ILogger
+        {
+            public void Log(string message) { }
+            public void LogWarning(string message) { }
+            public void LogError(string message) { }
+            public void LogException(System.Exception exception) { }
+        }
+
+        private class TestSignal : ISignal { }
+
+        [Test]
+        public void SubscribeAndFire_InvokesCallback()
+        {
+            var logger = new MockLogger();
+            var bus = new SignalBus(logger);
+            int callCount = 0;
+
+            bus.Subscribe<TestSignal>(_ => callCount++);
+            bus.Fire(new TestSignal());
+
+            Assert.That(callCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Unsubscribe_RemovesCallback()
+        {
+            var logger = new MockLogger();
+            var bus = new SignalBus(logger);
+            int callCount = 0;
+            ISignalBus.SignalHandler<TestSignal> handler = _ => callCount++;
+
+            bus.Subscribe(handler);
+            bus.Unsubscribe(handler);
+            bus.Fire(new TestSignal());
+
+            Assert.That(callCount, Is.EqualTo(0));
+        }
+    }
+}

--- a/Tests/Editor/SignalBusTests.cs.meta
+++ b/Tests/Editor/SignalBusTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44a842d8408746bab72ee7e069495d37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add unit tests for SignalBus subscribe/fire/unsubscribe logic
- cover cooldown behaviour of DebouncedExecutorUnity with Unity tests

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842ed212ae483329975d6270828b6f2